### PR TITLE
SQL Injection

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,8 +17,12 @@ if ($conn->connect_error) {
 // El siguiente código es vulnerable a SQL Injection ya que el input del usuario se concatena directamente en la consulta SQL sin validación o sanitización.
 if(isset($_GET['id'])) {
     $id = $_GET['id']; // Input del usuario tomado directamente desde la URL
-    $sql = "SELECT * FROM usuarios WHERE id = $id"; // Vulnerable a SQL Injection
-    $result = $conn->query($sql);
+    // José Hernández
+    // Usar una consulta preparada para evitar SQL Injection
+    $stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?");
+    $stmt->bind_param("i", $id); // Vincular el parámetro como un entero
+    $stmt->execute();
+    $result = $stmt->get_result();
 
     if ($result->num_rows > 0) {
         while($row = $result->fetch_assoc()) {
@@ -27,6 +31,8 @@ if(isset($_GET['id'])) {
     } else {
         echo "0 resultados";
     }
+
+    $stmt->close(); // Cerrar la declaración preparada
 }
 
 // Vulnerabilidad de Cross-Site Scripting (XSS)


### PR DESCRIPTION
The code was modified to mitigate SQL injection by replacing direct concatenation of user input with a prepared statement. Instead of inserting the $_GET['id'] directly into the SQL query string, the code now prepares a SQL statement with a parameter placeholder (?), binds the user-supplied ID as an integer, and then executes the statement. This approach prevents any malicious SQL input from altering the intended query, as the input is treated strictly as data. Additionally, the prepared statement is properly closed after use. Future best practices include validating and sanitizing user inputs, using parameterized queries consistently, and addressing any other potential vulnerabilities such as Cross-Site Scripting (XSS) elsewhere in the code.

Created by: jose.hernandez@a3sec.com